### PR TITLE
Update cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.24)
 project(change-refactoring-cpp-kata CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
FIND_PACKAGE_ARGS (used in cmake/FetchGTest.cmake) was added in version 3.24